### PR TITLE
Prevent cursor interfering with QR code

### DIFF
--- a/components/digid_x/app/assets/stylesheets/includes/qr_code.scss
+++ b/components/digid_x/app/assets/stylesheets/includes/qr_code.scss
@@ -71,6 +71,7 @@ h2.orange_heading + .qr_code {
   image-rendering: pixelated;                 /* Chromes                         */
   -ms-interpolation-mode: nearest-neighbor;   /* IE8+                           */
   text-align: center;
+  cursor: none;
 }
 
 .digid-qr-code-logo{


### PR DESCRIPTION
Interesting "bugfix" (configuration) for preventing the cursor to display over the QR-code that is generated